### PR TITLE
Fix class and course name

### DIFF
--- a/frontend/src/containers/EditSchedule/utils/index.js
+++ b/frontend/src/containers/EditSchedule/utils/index.js
@@ -3,7 +3,8 @@ import { getCourses } from "services/api"
 const mapScheduleItemsByName = (scheduleArray) => {
     let result = {}
     scheduleArray.forEach(sched => {
-        result[sched.name] = sched;
+        const key = `${sched.course_name}-${sched.name}`;
+        result[key] = sched;
     })
     return result;
 }
@@ -18,10 +19,13 @@ const formatScheduleFromCourse = (courses, schedule) => {
     courseList.forEach(course => {
         const { classes } = course;
         classes.forEach(classItem => {
-            if (classItem.name in scheduleMap && !(classItem.name in added)) {
-                added[classItem.name] = 1;
+            const classKey = `${course.name}-${classItem.name}`;
+            if (classKey in scheduleMap && !(classKey in added)) {
+                added[classKey] = 1;
+                // add Matched class schedule to result
                 result.push({ ...classItem, credit: course.credit, parentName: course.name, term: course.term, name: classItem.name })
-                savedSchedule.schedule_items = savedSchedule.schedule_items.filter(sched => sched.name !== classItem.name)
+                // removing Matched class schedule from savedSchedule, so it became remainingSchedule
+                savedSchedule.schedule_items = savedSchedule.schedule_items.filter(sched => (sched.name !== classItem.name && sched.course_name !== course.name))
             }
         })
     })

--- a/frontend/src/containers/SelectedCourses/index.js
+++ b/frontend/src/containers/SelectedCourses/index.js
@@ -29,7 +29,10 @@ function transformSchedules(schedules) {
     .map(schedule =>
       schedule.schedule_items.map(item => ({
         ...item,
-        name: schedule.name
+        name: schedule.name,
+        course_name: schedule.parentName,
+        sks: schedule.credit,
+        lecturer: schedule.lecturer
       }))
     )
     .reduce((prev, now) => [...prev, ...now], []);
@@ -81,6 +84,7 @@ function SelectedCourses({ history, scheduleId, isEditing }) {
   const items = schedules.map((schedule, idx) => {
     const isCurrentScheduleConflict = isScheduleConflict(schedules, schedule);
     isConflict = isConflict || isCurrentScheduleConflict;
+    const labelName = (String(schedule.name).includes(schedule.parentName)) ? schedule.name : `${schedule.parentName}-${schedule.name}`
 
     const classesTimes = schedule.schedule_items.map((item, index) => (
       <li key={index}>
@@ -90,7 +94,7 @@ function SelectedCourses({ history, scheduleId, isEditing }) {
 
     return (
       <TableContentRow key={idx} inverted={isCurrentScheduleConflict}>
-        <div className="courseName">{schedule.name}</div>
+        <div className="courseName">{labelName}</div>
         <div><ul>{classesTimes}</ul></div>
         <div className="small-2 columns">
           <span>{schedule.credit}</span>

--- a/frontend/src/containers/ViewSchedule/Schedule.js
+++ b/frontend/src/containers/ViewSchedule/Schedule.js
@@ -67,7 +67,7 @@ function Schedule({
           </TimeLabel>
         ))}
       {schedule &&
-        schedule.schedule_items.map(({ day, start, end, room, name }, idx) => (
+        schedule.schedule_items.map(({ day, start, end, room, name, course_name }, idx) => (
           <ScheduleItem
             key={`${schedule.name}-${idx}`}
             start={displayToMinute(start)}
@@ -84,7 +84,9 @@ function Schedule({
             )}
             <div className="content">
               {showRoom && isMobile && <span>{room}</span>}
-              <span style={{ fontSize: isMobile?  "8px": "12px", color:"#F7B500",  mixBlendMode: "normal"}}>{name}</span>
+              <span style={{ fontSize: isMobile?  "8px": "12px", color:"#F7B500",  mixBlendMode: "normal"}}>
+                {(String(name).includes(course_name) || !course_name) ? name : `${course_name} - ${name}`}
+              </span>
             </div>
           </ScheduleItem>
         ))}

--- a/frontend/src/containers/ViewSchedule/ScheduleList.js
+++ b/frontend/src/containers/ViewSchedule/ScheduleList.js
@@ -4,25 +4,27 @@ import styled from "styled-components";
 const ScheduleList = ({ schedule }) => {
   if (schedule) {
     const formattedSchedule = {};
-    schedule.schedule_items.forEach((scheduleItem) => {
-      if (!(scheduleItem.name in formattedSchedule)) {
-        formattedSchedule[scheduleItem.name] = {
-          name: scheduleItem.name,
+    schedule.schedule_items.forEach(({name, start, end, day, room, course_name}) => {
+      const scheduleKey =  `${course_name}-${name}`;
+      const formatedName = (String(name).includes(course_name) || !course_name) ? name : `${course_name} - ${name}`
+      if (!(scheduleKey in formattedSchedule)) {
+        formattedSchedule[scheduleKey] = {
+          name: formatedName,
           time: [
             {
-              start: scheduleItem.start,
-              end: scheduleItem.end,
-              day: scheduleItem.day,
-              room: scheduleItem.room,
+              start: start,
+              end: end,
+              day: day,
+              room: room,
             },
           ],
         };
       } else {
-        formattedSchedule[scheduleItem.name].time.push({
-          start: scheduleItem.start,
-          end: scheduleItem.end,
-          day: scheduleItem.day,
-          room: scheduleItem.room,
+        formattedSchedule[scheduleKey].time.push({
+          start: start,
+          end: end,
+          day: day,
+          room: room,
         });
       }
     });


### PR DESCRIPTION
So i fix frontend based on data model changes in  #106 
it makes more reliable matching and displaying course and class name

by previous problem, the solution is making `${courseName}-${className}` as key to match schedules and courses. 

And also while saving the schedule or displaying schedule name, if `className` already contains `courseName` it wont be added as prefix, otherwise it will add `courseName` as prefix for `className`. It is for solvig this issue #99 when `className` are not provide full information.
but since we never know how academy administration would fill the name, might happen like this. works fine on Aljabar Linier,  but on **Analitika Medsos** have different name with course name which is **"Analitika Media Sosial"** and this happen.
![image](https://user-images.githubusercontent.com/47312797/127344444-8aeb5eda-aaef-4350-a2e5-d2a6257fb46f.png)


Last,  since the data format and matching changed. If there is old format of schedule, when u try to update it will appear as **agenda**, because it is not match with the new format.
![image](https://user-images.githubusercontent.com/47312797/127345149-fecf07cf-939f-4aae-83fd-d08667d6a20a.png)
So i suggest to reset **user schedule** database before launching SusunJadwal with this new fix.

